### PR TITLE
Misc additions

### DIFF
--- a/bin/dart.wwwdotorg.org/conf.seaboard_na
+++ b/bin/dart.wwwdotorg.org/conf.seaboard_na
@@ -20,6 +20,7 @@
 
 console_dev=/dev/serial/by-path/pci-0000:00:1d.0-usb-0:1.4:1.0-port0
 power_impl=none_yet
+flash_impl=none
 recovery_impl=relay
 recovery_relay_bin="${HOME}/ubtest-usb-relays/bin"
 recovery_relay_type=numato

--- a/bin/flash.none
+++ b/bin/flash.none
@@ -18,16 +18,4 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-console_dev=/dev/serial/by-path/pci-0000:00:1d.7-usb-0:4.1:1.2-port0
-power_impl=eimt_pm342
-flash_impl=none
-eimt_board=tegra114-dalmore-a04
-recovery_impl=pm342
-nv_board_automation_bin="${HOME}/ubtest-gitmaster-tegra-tools-private/board_automation"
-pm342_serial=dalmore-a04-a
-board_usb_dev=/dev/usbdev-tegra114-dalmore-a04
-download_impl=tegra-uboot-flasher
-tubf_bin="${HOME}/ubtest-tegra-uboot-flasher/scripts"
-tubf_board=dalmore
-tubf_config=dalmore-t40s-1600
-board_usb_port_path=2-4.2
+# No flashing needed

--- a/bin/poweroff.digital-loggers
+++ b/bin/poweroff.digital-loggers
@@ -1,0 +1,22 @@
+# Copyright (c) 2016 Konsulko Group. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+curl --data ${power_port}=OFF -o /dev/null --silent \
+	http://${power_user:-admin}:${power_pass:-1234}@${power_ip}/outlet

--- a/bin/poweron.digital-loggers
+++ b/bin/poweron.digital-loggers
@@ -1,0 +1,22 @@
+# Copyright (c) 2016 Konsulko Group. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+curl --data ${power_port}=ON -o /dev/null --silent \
+	http://${power_user:-admin}:${power_pass:-1234}@${power_ip}/outlet

--- a/bin/reset.digital-loggers
+++ b/bin/reset.digital-loggers
@@ -1,0 +1,22 @@
+# Copyright (c) 2016 Konsulko Group. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+curl --data ${power_port}=CCL -o /dev/null --silent \
+	http://${power_user:-admin}:${power_pass:-1234}@${power_ip}/outlet

--- a/bin/reset.tegra-usb-recovery
+++ b/bin/reset.tegra-usb-recovery
@@ -1,4 +1,4 @@
-# Copyright (c) 2015, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2015-2016, NVIDIA CORPORATION. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -18,16 +18,15 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-console_dev=/dev/serial/by-path/pci-0000:00:14.0-usb-0:6:1.2-port0
-power_impl=pm342
-flash_impl=none
-reset_impl=tegra-usb-recovery
-recovery_impl=pm342
-nv_board_automation_bin="${HOME}/ubtest-nvidia-board-automation"
-pm342_serial=SRW-0
-board_usb_dev=/dev/usbdev-p2371-2180
-download_impl=tegra-uboot-flasher
-tubf_bin="${HOME}/shared/git_wa/tegra-uboot-flasher/scripts"
-tubf_board=dalmore
-tubf_config=dalmore-t40s-1600
-board_usb_port_path=3-13
+. "${bin_dir}/recovery.${recovery_impl}"
+
+# USB enumeration delay
+for ((i = 0; i <= 100; i++)); do
+    if [ -e "${board_usb_dev}" ]; then
+        break
+    fi
+    sleep 0.1
+done
+sleep 1
+
+. "${bin_dir}/download.${download_impl}"

--- a/bin/swarren-lx1/conf.dalmore_na
+++ b/bin/swarren-lx1/conf.dalmore_na
@@ -20,6 +20,7 @@
 
 console_dev=/dev/serial/by-path/pci-0000:00:14.0-usb-0:6:1.2-port0
 power_impl=pm342
+flash_impl=none
 recovery_impl=pm342
 nv_board_automation_bin="${HOME}/ubtest-nvidia-board-automation"
 pm342_serial=SRW-0

--- a/bin/swarren-lx1/conf.jetson-tk1_na
+++ b/bin/swarren-lx1/conf.jetson-tk1_na
@@ -20,6 +20,7 @@
 
 console_dev=/dev/ttyS0
 power_impl=manual
+flash_impl=none
 recovery_impl=manual
 board_usb_dev=/dev/usbdev-jetson-tk1
 download_impl=tegra-uboot-flasher

--- a/bin/swarren-lx1/conf.jetson-tk1_na
+++ b/bin/swarren-lx1/conf.jetson-tk1_na
@@ -21,6 +21,7 @@
 console_dev=/dev/ttyS0
 power_impl=manual
 flash_impl=none
+reset_impl=tegra-usb-recovery
 recovery_impl=manual
 board_usb_dev=/dev/usbdev-jetson-tk1
 download_impl=tegra-uboot-flasher

--- a/bin/swarren-lx1/conf.p2371-2180_na
+++ b/bin/swarren-lx1/conf.p2371-2180_na
@@ -20,6 +20,7 @@
 
 console_dev=/dev/serial/by-path/pci-0000:00:14.0-usb-0:6:1.2-port0
 power_impl=pm342
+flash_impl=none
 recovery_impl=pm342
 nv_board_automation_bin="${HOME}/ubtest-nvidia-board-automation"
 pm342_serial=SRW-0

--- a/bin/swarren-lx1/conf.p2371-2180_na
+++ b/bin/swarren-lx1/conf.p2371-2180_na
@@ -21,6 +21,7 @@
 console_dev=/dev/serial/by-path/pci-0000:00:14.0-usb-0:6:1.2-port0
 power_impl=pm342
 flash_impl=none
+reset_impl=tegra-usb-recovery
 recovery_impl=pm342
 nv_board_automation_bin="${HOME}/ubtest-nvidia-board-automation"
 pm342_serial=SRW-0

--- a/bin/tamien/conf.beaver_na
+++ b/bin/tamien/conf.beaver_na
@@ -20,6 +20,7 @@
 
 console_dev=/dev/serial/by-path/pci-0000:00:1d.7-usb-0:4.5:1.0-port0
 power_impl=eimt_phidgets
+flash_impl=none
 eimt_board=tegra30-beaver
 phidgets_serial=132707
 phidgets_relay_power=0

--- a/bin/tamien/conf.beaver_na
+++ b/bin/tamien/conf.beaver_na
@@ -21,6 +21,7 @@
 console_dev=/dev/serial/by-path/pci-0000:00:1d.7-usb-0:4.5:1.0-port0
 power_impl=eimt_phidgets
 flash_impl=none
+reset_impl=tegra-usb-recovery
 eimt_board=tegra30-beaver
 phidgets_serial=132707
 phidgets_relay_power=0

--- a/bin/tamien/conf.dalmore_na
+++ b/bin/tamien/conf.dalmore_na
@@ -21,6 +21,7 @@
 console_dev=/dev/serial/by-path/pci-0000:00:1d.7-usb-0:4.1:1.2-port0
 power_impl=eimt_pm342
 flash_impl=none
+reset_impl=tegra-usb-recovery
 eimt_board=tegra114-dalmore-a04
 recovery_impl=pm342
 nv_board_automation_bin="${HOME}/ubtest-gitmaster-tegra-tools-private/board_automation"

--- a/bin/tamien/conf.jetson-tk1_na
+++ b/bin/tamien/conf.jetson-tk1_na
@@ -21,6 +21,7 @@
 console_dev=/dev/serial/by-path/pci-0000:00:1d.7-usb-0:4.7.4:1.0-port0
 power_impl=eimt_phidgets
 flash_impl=none
+reset_impl=tegra-usb-recovery
 eimt_board=tegra124-jetson-tk1
 phidgets_serial=109237
 phidgets_relay_power=0

--- a/bin/tamien/conf.jetson-tk1_na
+++ b/bin/tamien/conf.jetson-tk1_na
@@ -20,6 +20,7 @@
 
 console_dev=/dev/serial/by-path/pci-0000:00:1d.7-usb-0:4.7.4:1.0-port0
 power_impl=eimt_phidgets
+flash_impl=none
 eimt_board=tegra124-jetson-tk1
 phidgets_serial=109237
 phidgets_relay_power=0

--- a/bin/tamien/conf.p2371-0000_na
+++ b/bin/tamien/conf.p2371-0000_na
@@ -21,6 +21,7 @@
 console_dev=/dev/serial/by-path/pci-0000:00:1d.7-usb-0:3.4.1:1.3-port0
 power_impl=eimt_pm342
 flash_impl=none
+reset_impl=tegra-usb-recovery
 eimt_board=tegra210-p2371-0000
 recovery_impl=pm342
 nv_board_automation_bin="${HOME}/ubtest-gitmaster-tegra-tools-private/board_automation"

--- a/bin/tamien/conf.p2371-0000_na
+++ b/bin/tamien/conf.p2371-0000_na
@@ -20,6 +20,7 @@
 
 console_dev=/dev/serial/by-path/pci-0000:00:1d.7-usb-0:3.4.1:1.3-port0
 power_impl=eimt_pm342
+flash_impl=none
 eimt_board=tegra210-p2371-0000
 recovery_impl=pm342
 nv_board_automation_bin="${HOME}/ubtest-gitmaster-tegra-tools-private/board_automation"

--- a/bin/u-boot-test-flash
+++ b/bin/u-boot-test-flash
@@ -28,4 +28,4 @@ board_ident="$2"
 hostname="`hostname`"
 . "${bin_dir}/${hostname}/conf.${board_type}_${board_ident}"
 
-echo No flashing needed - using tegra-uboot-flasher
+. "${bin_dir}/flash.${flash_impl}"

--- a/bin/u-boot-test-reset
+++ b/bin/u-boot-test-reset
@@ -28,15 +28,4 @@ board_ident="$2"
 hostname="`hostname`"
 . "${bin_dir}/${hostname}/conf.${board_type}_${board_ident}"
 
-. "${bin_dir}/recovery.${recovery_impl}"
-
-# USB enumeration delay
-for ((i = 0; i <= 100; i++)); do
-    if [ -e "${board_usb_dev}" ]; then
-        break
-    fi
-    sleep 0.1
-done
-sleep 1
-
-. "${bin_dir}/download.${download_impl}"
+. "${bin_dir}/reset.${reset_impl}"


### PR DESCRIPTION
- Create tegra-usb-recovery method to cover the current use case of Tegra HW
- Add a flash.none for boards that do not perform a flash
- Add digital-loggers poweron/off/reset scripts.  These will use the HW default user/pass if not provided in the board config file.

For the digital-loggers part, I've seen these devices used in several labs over the years and no one changes the user/pass (they're never on the internet and always in a test lab). I feel adding the default to each board would be more clutter than allowing the default to be used.
