### PR TITLE
bin: Add flashair hooks for flashing U-Boot

### DIFF
--- a/bin/flash.flashair
+++ b/bin/flash.flashair
@@ -1,0 +1,45 @@
+# Copyright (c) 2016 Konsulko Group. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+# Make sure that the card is available to us now.
+while true; do
+    ping -c 1 ${flashair_ip} >/dev/null 2>&1
+    if [ $? -eq 0 ]; then
+        break;
+    fi
+done
+
+# Make our new holding space.
+UL_DIR=`mktemp -d`
+
+# Run this script to copy files as they must appear on the target into
+# the given directory.
+. "${bin_dir}/${flashair_copy_script}"
+
+# Collect all arguments
+ARGS=()
+if [ ! -z "${flashair_rmlist}" ]; then
+  ARGS+=("rmlist:${flashair_rmlist}")
+fi
+
+ARGS+=("push:${UL_DIR}")
+push-flashair.py ${flashair_ip} "${ARGS[@]}"
+
+rm -rf "${UL_DIR}" "${flashair_rmlist}"

--- a/bin/flashair.rpi
+++ b/bin/flashair.rpi
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Copyright (c) 2016 Stephen Warren <swarren@wwwdotorg.org>
+# Copyright (c) 2016 Konsulko Group
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+flashair_rmlist=`mktemp`
+
+case "${board_type}" in
+rpi)
+    kernel_dst=kernel.img
+    ;;
+rpi_2)
+    kernel_dst=kernel7.img
+    ;;
+rpi_3)
+    kernel_dst=kernel8.img
+    ;;
+rpi_3_32b)
+    kernel_dst=kernel8-32.img
+    ;;
+*)
+    echo Unknown Pi \""${board_type}"\"
+    exit 1
+    ;;
+esac
+
+echo 'kern*.img' > "${flashair_rmlist}"
+
+cp "${U_BOOT_BUILD_DIR}"/u-boot.bin "${UL_DIR}"/"${kernel_dst}"
+
+touch "${UL_DIR}/config.txt"
+
+echo "enable_uart=1" >> "${UL_DIR}/config.txt"
+
+case "${board_ident}" in
+3-32-pl011)
+    echo "dtoverlay=pi3-miniuart-bt" >> "${UL_DIR}/config.txt"
+    ;;
+esac

--- a/bin/flashair.ti-omap
+++ b/bin/flashair.ti-omap
@@ -1,0 +1,26 @@
+# Copyright (c) 2016 Konsulko Group. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+#
+# This script will copy the 'MLO' and 'u-boot.img' files into the correct
+# location for the flashair wrapper to upload them.  The 'MLO' file is what
+# the ROM found in most 32bit TI platforms (other than the Keystone family)
+# will look for when booting from a FAT partition.
+
+cp "${U_BOOT_BUILD_DIR}"/{MLO,u-boot.img} "${UL_DIR}/"

--- a/bin/push-flashair.py
+++ b/bin/push-flashair.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2016 Stephen Warren <swarren@wwwdotorg.org>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+import fnmatch
+import os
+import requests
+import sys
+try:
+    from os import scandir
+except ImportError:
+    from scandir import scandir
+
+def push_file(host, local_path, remote_name):
+    print('..PUSH FILE: ' + remote_name)
+    files = {'file': (remote_name, open(local_path,'rb'))}
+    response = requests.post('http://%s/upload.cgi' % host, files=files)
+    print('.... ' + str(response.status_code))
+    response.raise_for_status()
+    if 'NG' in response.text or 'action=/upload.cgi' not in response.text:
+        print('Upload failed:', file=sys.stderr)
+        print(response.text, file=sys.stderr)
+        sys.exit(1)
+
+def op_push_dir(host, local_dir):
+    print('PUSH DIR: ' + local_dir)
+    for de in scandir(local_dir):
+        if not de.is_file():
+            print('Can\'t handle non-file "%s"' % de.path, file=sys.stderr)
+            sys.exit(1)
+        push_file(host, de.path, de.name)
+
+def op_rm_list(host, rm_list_file):
+    print('RM LIST: ' + rm_list_file)
+    params = {'op': 100, 'DIR': '/'}
+    response = requests.get('http://%s/command.cgi' % host, params)
+    response.raise_for_status()
+    lines = response.text.splitlines()
+    if lines[0] != 'WLANSD_FILELIST':
+        print('File list qery failed:', file=sys.stderr)
+        print(response.text, file=sys.stderr)
+        sys.exit(1)
+    existing_files = []
+    for l in lines[1:]:
+        existing_files.append(l.split(',')[1].lower())
+    with open(rm_list_file, 'rt') as fh:
+        for l in fh:
+            l = l.split('#')[0]
+            rmspec = l.strip().lower()
+            if not rmspec:
+                continue
+            for remote_filename in existing_files[:]:
+                if fnmatch.fnmatch(remote_filename, rmspec):
+                    print('..DELETE: ' + remote_filename)
+                    params = {'DEL': '/' + remote_filename}
+                    response = requests.get('http://%s/upload.cgi' % host, params)
+                    print('.... ' + str(response.status_code))
+                    response.raise_for_status()
+                    if 'SUCCESS' not in response.text:
+                        print('Delete failed:', file=sys.stderr)
+                        print(response.text, file=sys.stderr)
+                        sys.exit(1)
+
+op_map = {
+    'push': op_push_dir,
+    'rmlist': op_rm_list,
+}
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Copy files to a Toshiba FlashAir device')
+    parser.add_argument('host', help='The host or host:port of the FlashAir')
+    parser.add_argument('ops', nargs='+', help='''Operations to perform;
+    "dir", "push:dir": push directory, "rmlist:listfile": delete files listed
+    in listfile''')
+    args = parser.parse_args()
+
+    for op in args.ops:
+        if not ':' in op:
+            func = op_push_dir
+            param = op
+        else:
+            (op_name, param) = op.split(':', 1)
+            if op_name not in op_map:
+                print('"%s" is not a valid operation' % op_name,
+                    file=sys.stderr)
+                parser.print_help(file=sys.stderr)
+                sys.exit(1)
+            func = op_map[op_name]
+        func(args.host, param)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- We copy push-flashair.py from Stephen's rpi-dev-scripts repository to
  talk with the Toshiba "FlashAir" SD cards, which are full size SD
  cards that use the iSDIO specification to also have 802.11 wireless
  capability and a certain amount of remote functionality.  With UPLOAD=1
  set in the config file you can upload files to these cards.
- We copy and then modify uboot-gen.sh from the rpi-dev-scripts
  repository to figure out what the u-boot.bin file needs to be called
  on the target RPi.
- I've added a flashair.ti-omap script that will copy MLO/u-boot.img
  files as these are what most TI platforms use to boot.

Signed-off-by: Tom Rini trini@konsulko.com

---

Changes in v2:
- I added ARGS to flash.flashair so that we can put in rmlist: only if we have files to remove and then append the push:dir to the args after.  Tested on both TI platforms and RPi 3 (32bit and 64bit).

Changes in v3:
- ARGS is spaces safe now (Tested with rmlist and without with TMPDIR="/tmp/path with spaces"), ping is done more cleanly but still relies on upper levels to determine that timeout has a happened
