### PR TITLE
Add network and efi_loader test coverage to Travis-CI

### DIFF
--- a/bin/travis-ci/conf.qemu-x86_na
+++ b/bin/travis-ci/conf.qemu-x86_na
@@ -21,7 +21,7 @@
 console_impl=qemu
 qemu_machine="pc"
 qemu_binary="qemu-system-i386"
-qemu_extra_args="-nographic -cpu qemu32 -netdev user,id=net0,tftp=/tftpboot -device e1000,netdev=net0"
+qemu_extra_args="-nographic -cpu qemu32 -netdev user,id=net0,tftp=${UBOOT_TRAVIS_BUILD_DIR} -device e1000,netdev=net0"
 qemu_kernel_args="-bios ${U_BOOT_BUILD_DIR}/u-boot.rom"
 reset_impl=none
 flash_impl=none

--- a/bin/travis-ci/conf.vexpress_ca15_tc2_qemu
+++ b/bin/travis-ci/conf.vexpress_ca15_tc2_qemu
@@ -21,7 +21,7 @@
 console_impl=qemu
 qemu_machine="vexpress-a15"
 qemu_binary="qemu-system-arm"
-qemu_extra_args="-nographic -m 1G -tftp /tftpboot"
+qemu_extra_args="-nographic -m 1G -tftp ${UBOOT_TRAVIS_BUILD_DIR}"
 qemu_kernel_args="-kernel ${U_BOOT_BUILD_DIR}/u-boot"
 reset_impl=none
 flash_impl=none

--- a/bin/travis-ci/conf.vexpress_ca9x4_qemu
+++ b/bin/travis-ci/conf.vexpress_ca9x4_qemu
@@ -21,7 +21,7 @@
 console_impl=qemu
 qemu_machine="vexpress-a9"
 qemu_binary="qemu-system-arm"
-qemu_extra_args="-nographic -m 1G -tftp /tftpboot"
+qemu_extra_args="-nographic -m 1G -tftp ${UBOOT_TRAVIS_BUILD_DIR}"
 qemu_kernel_args="-kernel ${U_BOOT_BUILD_DIR}/u-boot"
 reset_impl=none
 flash_impl=none

--- a/py/travis-ci/travis_tftp.py
+++ b/py/travis-ci/travis_tftp.py
@@ -1,0 +1,11 @@
+import os
+import binascii
+
+def file2env(file_name):
+    file_full = os.environ['UBOOT_TRAVIS_BUILD_DIR'] + "/" + file_name
+
+    return {
+        "fn": file_name,
+        "size": os.path.getsize(file_full),
+        "crc32": hex(binascii.crc32(open(file_full, 'rb').read()) & 0xffffffff)[2:],
+    }

--- a/py/travis-ci/u_boot_boardenv_qemu_x86_na.py
+++ b/py/travis-ci/u_boot_boardenv_qemu_x86_na.py
@@ -1,0 +1,6 @@
+import travis_tftp
+
+env__net_uses_pci = True
+env__net_dhcp_server = True
+
+env__net_tftp_readable_file = travis_tftp.file2env('u-boot')

--- a/py/travis-ci/u_boot_boardenv_qemu_x86_na.py
+++ b/py/travis-ci/u_boot_boardenv_qemu_x86_na.py
@@ -4,3 +4,4 @@ env__net_uses_pci = True
 env__net_dhcp_server = True
 
 env__net_tftp_readable_file = travis_tftp.file2env('u-boot')
+env__efi_loader_helloworld_file = travis_tftp.file2env('lib/efi_loader/helloworld.efi')

--- a/py/travis-ci/u_boot_boardenv_qemu_x86_na.py
+++ b/py/travis-ci/u_boot_boardenv_qemu_x86_na.py
@@ -5,3 +5,6 @@ env__net_dhcp_server = True
 
 env__net_tftp_readable_file = travis_tftp.file2env('u-boot')
 env__efi_loader_helloworld_file = travis_tftp.file2env('lib/efi_loader/helloworld.efi')
+
+env__efi_loader_check_smbios = True
+env__efi_loader_grub_file = travis_tftp.file2env('grub_x86.efi')

--- a/py/travis-ci/u_boot_boardenv_vexpress_ca15_tc2_qemu.py
+++ b/py/travis-ci/u_boot_boardenv_vexpress_ca15_tc2_qemu.py
@@ -3,3 +3,4 @@ import travis_tftp
 env__net_dhcp_server = True
 
 env__net_tftp_readable_file = travis_tftp.file2env('u-boot')
+env__efi_loader_helloworld_file = travis_tftp.file2env('lib/efi_loader/helloworld.efi')

--- a/py/travis-ci/u_boot_boardenv_vexpress_ca15_tc2_qemu.py
+++ b/py/travis-ci/u_boot_boardenv_vexpress_ca15_tc2_qemu.py
@@ -4,3 +4,4 @@ env__net_dhcp_server = True
 
 env__net_tftp_readable_file = travis_tftp.file2env('u-boot')
 env__efi_loader_helloworld_file = travis_tftp.file2env('lib/efi_loader/helloworld.efi')
+env__efi_loader_grub_file = travis_tftp.file2env('grub_arm.efi')

--- a/py/travis-ci/u_boot_boardenv_vexpress_ca15_tc2_qemu.py
+++ b/py/travis-ci/u_boot_boardenv_vexpress_ca15_tc2_qemu.py
@@ -1,0 +1,5 @@
+import travis_tftp
+
+env__net_dhcp_server = True
+
+env__net_tftp_readable_file = travis_tftp.file2env('u-boot')

--- a/py/travis-ci/u_boot_boardenv_vexpress_ca9x4_qemu.py
+++ b/py/travis-ci/u_boot_boardenv_vexpress_ca9x4_qemu.py
@@ -3,3 +3,4 @@ import travis_tftp
 env__net_dhcp_server = True
 
 env__net_tftp_readable_file = travis_tftp.file2env('u-boot')
+env__efi_loader_helloworld_file = travis_tftp.file2env('lib/efi_loader/helloworld.efi')

--- a/py/travis-ci/u_boot_boardenv_vexpress_ca9x4_qemu.py
+++ b/py/travis-ci/u_boot_boardenv_vexpress_ca9x4_qemu.py
@@ -4,3 +4,4 @@ env__net_dhcp_server = True
 
 env__net_tftp_readable_file = travis_tftp.file2env('u-boot')
 env__efi_loader_helloworld_file = travis_tftp.file2env('lib/efi_loader/helloworld.efi')
+env__efi_loader_grub_file = travis_tftp.file2env('grub_arm.efi')

--- a/py/travis-ci/u_boot_boardenv_vexpress_ca9x4_qemu.py
+++ b/py/travis-ci/u_boot_boardenv_vexpress_ca9x4_qemu.py
@@ -1,0 +1,5 @@
+import travis_tftp
+
+env__net_dhcp_server = True
+
+env__net_tftp_readable_file = travis_tftp.file2env('u-boot')


### PR DESCRIPTION
So far the Travis checks did not include network or efi tests. With these patches, they can.

To actually make use of these, additional patches to the U-Boot tree are necessary. But having the files in this tree first shouldn't hurt.