### PR TITLE
travis: Skip files that don't exist

### DIFF
--- a/py/travis-ci/travis_tftp.py
+++ b/py/travis-ci/travis_tftp.py
@@ -4,6 +4,9 @@ import binascii
 def file2env(file_name):
     file_full = os.environ['UBOOT_TRAVIS_BUILD_DIR'] + "/" + file_name
 
+    if not os.path.isfile(file_full):
+        return None
+
     return {
         "fn": file_name,
         "size": os.path.getsize(file_full),


### PR DESCRIPTION
The travis tftp helper exposes files from the host into the guest environment.
However, depending on the travis configuration and patch status, files may or
may not exist yet.

So if we can't find a particular file, let's skip it.

Signed-off-by: Alexander Graf <agraf@suse.de>