### PR TITLE
Wire arm32 qemu for zynq_zc702 target

### DIFF
--- a/bin/travis-ci/conf.zynq_zc702_qemu
+++ b/bin/travis-ci/conf.zynq_zc702_qemu
@@ -1,0 +1,27 @@
+# Copyright (c) 2016 Xilinx, Inc. (Michal Simek). All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+console_impl=qemu
+qemu_machine="xilinx-zynq-a9"
+qemu_binary="qemu-system-arm"
+qemu_extra_args="-display none -m 40000000 -nographic -serial /dev/null -serial mon:stdio -monitor null"
+qemu_kernel_args="-kernel ${U_BOOT_BUILD_DIR}/u-boot"
+reset_impl=none
+flash_impl=none

--- a/py/travis-ci/u_boot_boardenv_zynq_zc702_qemu.py
+++ b/py/travis-ci/u_boot_boardenv_zynq_zc702_qemu.py
@@ -1,0 +1,1 @@
+env__spl_skipped = True


### PR DESCRIPTION
SPL is skipped because qemu version in ubuntu package does not support
qemu loader feature which could put images to certain location in the
memory. That's why testing is loading full u-boot directly without SPL
but buildmain builds target with SPL by default.

Signed-off-by: Michal Simek <michal.simek@xilinx.com>