### PR TITLE
zynq: Update target to work with qemu 2.8.0-rc3

### DIFF
--- a/bin/travis-ci/conf.zynq_zc702_qemu
+++ b/bin/travis-ci/conf.zynq_zc702_qemu
@@ -22,6 +22,6 @@ console_impl=qemu
 qemu_machine="xilinx-zynq-a9"
 qemu_binary="qemu-system-arm"
 qemu_extra_args="-display none -m 40000000 -nographic -serial /dev/null -serial mon:stdio -monitor null"
-qemu_kernel_args="-kernel ${U_BOOT_BUILD_DIR}/u-boot"
+qemu_kernel_args="-device loader,file=${U_BOOT_BUILD_DIR}/u-boot-dtb.bin,addr=0x4000000,cpu-num=0"
 reset_impl=none
 flash_impl=none


### PR DESCRIPTION
With this version new loader property can be used.

Signed-off-by: Michal Simek <monstr@monstr.eu>