### PR TITLE
travis-ci: Add qemu_arm64 board

### DIFF
--- a/bin/travis-ci/conf.qemu_arm64_na
+++ b/bin/travis-ci/conf.qemu_arm64_na
@@ -1,0 +1,29 @@
+# Copyright (c) 2017 Tuomas Tynkkynen. All rights reserved.
+# Based on conf.vexpress_ca15_tc2_qemu which is:
+# Copyright (c) 2016 Konsulko Group. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+console_impl=qemu
+qemu_machine="virt,highmem=off"
+qemu_binary="qemu-system-aarch64"
+qemu_extra_args="-cpu cortex-a57 -nographic -netdev user,id=net0,tftp=${UBOOT_TRAVIS_BUILD_DIR} -device e1000,netdev=net0"
+qemu_kernel_args="-bios ${U_BOOT_BUILD_DIR}/u-boot.bin"
+reset_impl=none
+flash_impl=none

--- a/py/travis-ci/u_boot_boardenv_qemu_arm64_na.py
+++ b/py/travis-ci/u_boot_boardenv_qemu_arm64_na.py
@@ -1,0 +1,8 @@
+import travis_tftp
+
+env__net_uses_pci = True
+env__net_dhcp_server = True
+
+env__net_tftp_readable_file = travis_tftp.file2env('u-boot.bin')
+env__efi_loader_helloworld_file = travis_tftp.file2env('lib/efi_loader/helloworld.efi')
+env__efi_loader_grub_file = travis_tftp.file2env('grub_arm64.efi')


### PR DESCRIPTION
This is emulated platform otherwise equivalent to the qemu_arm (submitted in #14) but with an AArch64 CPU.

I will submit the patch series adding the board to U-Boot soon.

Signed-off-by: Tuomas Tynkkynen <tuomas.tynkkynen@iki.fi>