### PR TITLE
bin/travis-ci: add conf.xtfpga_qemu

### DIFF
--- a/bin/travis-ci/conf.xtfpga_qemu
+++ b/bin/travis-ci/conf.xtfpga_qemu
@@ -1,0 +1,27 @@
+# Copyright (c) 2018 Cadence Design Systems Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+console_impl=qemu
+qemu_machine="kc705"
+qemu_binary="qemu-system-xtensa"
+qemu_extra_args="-nographic -monitor null -m 1G -cpu dc233c"
+qemu_kernel_args="-kernel ${U_BOOT_BUILD_DIR}/u-boot"
+reset_impl=none
+flash_impl=none


### PR DESCRIPTION
Hi Stephen,

please pull the following patch that allows running CI tests on xtensa port of U-Boot.

This is xtensa QEMU configuration that matches the xtfpga_defconfig from
U-Boot. It emulates KC705 with DC233C xtensa core in it.

Signed-off-by: Max Filippov <jcmvbkbc@gmail.com>