### PR TITLE
travis-ci: add qemu-ax25 (riscv64)

### DIFF
--- a/bin/travis-ci/conf.qemu-ax25_na
+++ b/bin/travis-ci/conf.qemu-ax25_na
@@ -1,0 +1,27 @@
+# Copyright (c) 2016 Konsulko Group. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+console_impl=qemu
+qemu_machine="andes_ae350"
+qemu_binary="qemu-system-riscv64"
+qemu_extra_args="-nographic -m 4G"
+qemu_kernel_args="-kernel ${U_BOOT_BUILD_DIR}/u-boot"
+reset_impl=none
+flash_impl=none

--- a/py/travis-ci/u_boot_boardenv_qemu-ax25_na.py
+++ b/py/travis-ci/u_boot_boardenv_qemu-ax25_na.py
@@ -1,0 +1,7 @@
+import travis_tftp
+
+env__net_uses_pci = True
+env__net_dhcp_server = True
+
+env__net_tftp_readable_file = travis_tftp.file2env('u-boot')
+env__efi_loader_helloworld_file = travis_tftp.file2env('lib/efi_loader/helloworld.efi')


### PR DESCRIPTION
Hi,

This patch is for running u-boot's travis CI tests on our ax25 board port. Thanks.

Signed-off-by: Rick Chen <rick@andestech.com>
Signed-off-by: Rick Chen <rickchen36@gmail.com>
Reviewed-by: Chih-Mao Chen <cmchen@andestech.com>
Cc: Greentime Hu <green.hu@gmail.com>