### PR TITLE
qemu_arm_na, qemu_arm64_na: Drop 'highmem=off' from QEMU machine

### DIFF
--- a/bin/travis-ci/conf.qemu_arm64_na
+++ b/bin/travis-ci/conf.qemu_arm64_na
@@ -21,7 +21,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 console_impl=qemu
-qemu_machine="virt,highmem=off"
+qemu_machine="virt"
 qemu_binary="qemu-system-aarch64"
 qemu_extra_args="-cpu cortex-a57 -nographic -netdev user,id=net0,tftp=${UBOOT_TRAVIS_BUILD_DIR} -device e1000,netdev=net0"
 qemu_kernel_args="-bios ${U_BOOT_BUILD_DIR}/u-boot.bin"

--- a/bin/travis-ci/conf.qemu_arm_na
+++ b/bin/travis-ci/conf.qemu_arm_na
@@ -21,7 +21,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 console_impl=qemu
-qemu_machine="virt,highmem=off"
+qemu_machine="virt"
 qemu_binary="qemu-system-arm"
 qemu_extra_args="-nographic -netdev user,id=net0,tftp=${UBOOT_TRAVIS_BUILD_DIR} -device e1000,netdev=net0"
 qemu_kernel_args="-bios ${U_BOOT_BUILD_DIR}/u-boot.bin"


### PR DESCRIPTION
As of commit https://github.com/u-boot/u-boot/commit/9792be7d933ed5 the
bug that necessitated the 'highmem=off' flag in QEMU for ARM/AArch64
when using U-Boot has been fixed. So drop the flag from the tests as
well.

Signed-off-by: Tuomas Tynkkynen <tuomas.tynkkynen@iki.fi>