### PR TITLE
Wire Xilinx Versal Qemu platform

### DIFF
--- a/bin/travis-ci/conf.xilinx_versal_virt_qemu
+++ b/bin/travis-ci/conf.xilinx_versal_virt_qemu
@@ -1,0 +1,27 @@
+# Copyright (c) 2018 Xilinx, Inc. (Michal Simek). All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+console_impl=qemu
+qemu_machine="xlnx-versal-virt"
+qemu_binary="qemu-system-aarch64"
+qemu_extra_args="-display none -m 4G -serial mon:stdio"
+qemu_kernel_args="-device loader,file=${U_BOOT_BUILD_DIR}/u-boot,cpu-num=0"
+reset_impl=none
+flash_impl=none


### PR DESCRIPTION
xlnx-versal-virt Qemu platform is generating DTB and placing it to
0x1000 offset. Then U-Boot is taking this DTB and using it for own
configuration.

Signed-off-by: Michal Simek <monstr@monstr.eu>