### PR TITLE
Convert Vexpress ca15_tc2/ca9x4 travis targets with new tftp wiring

### DIFF
--- a/bin/travis-ci/conf.vexpress_ca15_tc2_qemu
+++ b/bin/travis-ci/conf.vexpress_ca15_tc2_qemu
@@ -21,7 +21,7 @@
 console_impl=qemu
 qemu_machine="vexpress-a15"
 qemu_binary="qemu-system-arm"
-qemu_extra_args="-nographic -m 1G -tftp ${UBOOT_TRAVIS_BUILD_DIR}"
+qemu_extra_args="-nographic -m 1G -net user,tftp=${UBOOT_TRAVIS_BUILD_DIR} -net nic"
 qemu_kernel_args="-kernel ${U_BOOT_BUILD_DIR}/u-boot"
 reset_impl=none
 flash_impl=none

--- a/bin/travis-ci/conf.vexpress_ca9x4_qemu
+++ b/bin/travis-ci/conf.vexpress_ca9x4_qemu
@@ -21,7 +21,7 @@
 console_impl=qemu
 qemu_machine="vexpress-a9"
 qemu_binary="qemu-system-arm"
-qemu_extra_args="-nographic -m 1G -tftp ${UBOOT_TRAVIS_BUILD_DIR}"
+qemu_extra_args="-nographic -m 1G -net user,tftp=${UBOOT_TRAVIS_BUILD_DIR} -net nic"
 qemu_kernel_args="-kernel ${U_BOOT_BUILD_DIR}/u-boot"
 reset_impl=none
 flash_impl=none


### PR DESCRIPTION
Qemu has remove -tftp specification without connection to network
interface.
This was reported for some time by:
"The -tftp option is deprecated. Please use '-netdev user,tftp=...'
instead." message.

The patch is converting these platforms to be compatible with Qemu
v3.0.0 to fix travis issues when U-Boot adopts v3.1.0.

Reported-by: Tom Rini <trini@konsulko.com>
Signed-off-by: Michal Simek <monstr@monstr.eu>