### PR TITLE
vexpress_a15: Disable HYP mode for now

### DIFF
--- a/bin/travis-ci/conf.vexpress_ca15_tc2_qemu
+++ b/bin/travis-ci/conf.vexpress_ca15_tc2_qemu
@@ -21,7 +21,7 @@
 console_impl=qemu
 qemu_machine="vexpress-a15"
 qemu_binary="qemu-system-arm"
-qemu_extra_args="-nographic -m 1G -tftp ${UBOOT_TRAVIS_BUILD_DIR}"
+qemu_extra_args="-nographic -m 1G -tftp ${UBOOT_TRAVIS_BUILD_DIR} -cpu cortex-a15,has_el2=off"
 qemu_kernel_args="-kernel ${U_BOOT_BUILD_DIR}/u-boot"
 reset_impl=none
 flash_impl=none


### PR DESCRIPTION
QEMU v3.1.0 by default exposed EL2 (HYP) support in the A7 and A15 CPU
models.

For unknown reasons, that regresses the QEMU bootefi test case. Because
it is an unrelated bug, the best option for now is to force everything
back to the old behavior and then figure out concurrently what is broken.

Once we know we have a working base with HYP enabled, we can reenable it
for the test case again.

Signed-off-by: Alexander Graf <agraf@suse.de>