### PR TITLE
Add minnowmax with em100

### DIFF
--- a/bin/flash.em100
+++ b/bin/flash.em100
@@ -1,0 +1,30 @@
+# Copyright 2020 Google LLC
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+# Designed for using a Dediprog EM100Pro or Pro-G2 SPI-flash emulator
+# https://www.dediprog.com/product/EM100Pro-G2
+# (the older EM100Pro works but is not listed anymore)
+
+# It requires these tools:
+# em100 at https://review.coreboot.org/cgit/em100.git
+# Instructions at https://www.coreboot.org/EM100pro
+
+em100 -x "${em100_serial}" -s -p LOW -d "${U_BOOT_BUILD_DIR}/u-boot.rom" \
+    -c "${em100_chip}" -r

--- a/bin/kea/conf.minnowmax_sjg-minnowmax
+++ b/bin/kea/conf.minnowmax_sjg-minnowmax
@@ -1,0 +1,33 @@
+# Copyright 2020 Google LLC
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+console_dev=/dev/ttyusb_port7
+reset_impl=digital-loggers
+flash_impl=em100
+power_impl=digital-loggers
+
+power_ip="192.168.4.19"
+power_user="admin"
+power_pass="1234"
+power_port=6
+
+em100_dev=/dev/em100_0
+em100_serial=DP139140
+em100_chip=W25Q64DW


### PR DESCRIPTION
Add support for minnowmax which uses a Dediprog em100 ROM emulator.

Signed-off-by: Simon Glass <sjg@chromium.org>