### PR TITLE
Add chromebook_link

### DIFF
--- a/bin/common-config.cros-servo-dut-control
+++ b/bin/common-config.cros-servo-dut-control
@@ -1,0 +1,69 @@
+# Copyright 2020 Google LLC
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+# This can be included by config files to set the cros_servo_port and
+# console_dev variables.
+
+# It requires:
+# - standalone-hdctools to be installed at the same level as u-boot-test-hooks
+#     (i.e. at /path/to/u-boot-test-hooks/../standalone-hdctools)
+# - a servo board connected. Servo is used to control resetting the board and to
+#     access the serial console
+# - a servodrc also at the directory above u-boot-test-hooks (see sample below)
+# - 'servo_name' variable set to the board name, before including this script
+
+# Install hdctools here
+# https://chromium.googlesource.com/a/chromiumos/platform/standalone-hdctools
+
+# Information on servo here:
+# https://chromium.googlesource.com/chromiumos/third_party/hdctools/+/refs/heads/master/README.md
+
+# the ubtest directory holds u-boot-test-hooks and other things
+UBTEST_DIR="$(dirname "$(dirname "$(dirname "${BASH_SOURCE[0]}")")")"
+RCFILE="${UBTEST_DIR}/servodrc"
+DUT_CONTROL="${UBTEST_DIR}/standalone-hdctools/dut-control"
+
+# Look up the servo_name and get the port number
+cros_servo_port="$(grep ^${cros_servo_name}, ${RCFILE} |cut -f3 -d,)"
+if [ -z "${cros_servo_port}" ]; then
+    echo "Failed to find servo port for ${cros_servo_name}"
+    exit 1
+fi
+
+# Find the console
+console_dev="$(${DUT_CONTROL} -p ${cros_servo_port} cpu_uart_pty |cut -f2 -d:)"
+if [ -z "${console_dev}" ]; then
+    echo "Failed to find console for ${cros_servo_name}"
+    exit 1
+fi
+
+
+# Here is a sample servodrc
+# This file describes servo boards connected to this host.
+#
+# Line text starting with # to end of line is ignored, as well as empy lines.
+#
+# Configuration lines consist of up to 4 comma separated fields, the last
+# two are optional:
+#
+# name serial-number port-number board
+#
+# Remove the # from the next line
+# link, 905537-00223, 9902, link

--- a/bin/kea/conf.chromebook_link_sjg-link
+++ b/bin/kea/conf.chromebook_link_sjg-link
@@ -1,0 +1,30 @@
+# Copyright 2020 Google LLC
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+reset_impl=cros_servo
+flash_impl=em100
+power_impl=cros_servo
+
+em100_chip=W25Q64FV
+em100_serial=DP022781
+
+cros_servo_name=link
+
+. common-config.cros-servo-dut-control

--- a/bin/reset.cros_servo
+++ b/bin/reset.cros_servo
@@ -1,0 +1,23 @@
+# Copyright 2020 Google LLC. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+# Uses servo to reset the board
+
+${DUT_CONTROL} -p ${cros_servo_port} cold_reset:on sleep:.2 cold_reset:off


### PR DESCRIPTION
This uses servo to control the board and to access the serial console. It
uses em100 to write the flash. Add support for this.

Signed-off-by: Simon Glass <sjg@chromium.org>