### PR TITLE
Add support for rock2

### DIFF
--- a/bin/kea/conf.rock2_sjg-rock2
+++ b/bin/kea/conf.rock2_sjg-rock2
@@ -1,0 +1,33 @@
+# Copyright (c) 2020 Google LLC. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+console_dev=/dev/ttyusb_port8
+reset_impl=ykush
+flash_impl=sdwire_poweroff_raw
+power_impl=ykush
+
+flash_writer=rk3288_raw
+
+ykush_serial=YK17698
+ykush_port=3
+
+sdwire_serial=sdwireda10
+
+raw_device=/dev/sdcard3

--- a/bin/writer.rk3288_raw
+++ b/bin/writer.rk3288_raw
@@ -1,0 +1,40 @@
+# Copyright 202 Google LLC. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+# Writes Rockchip RK3288 image to the board
+
+# Args:
+#  $1: Device path of the sdcard when board is off (e.g. /dev/sdcard0)
+#  $2: U-Boot build directory
+
+set -ex
+
+device=$1
+build=$2
+
+tmp=${build}
+
+echo "Writing to ${device} from build at ${build}"
+
+${build}/tools/mkimage -n rk3288 -T rksd -d ${build}/spl/u-boot-spl.bin \
+    ${tmp}/out
+cat ${build}/u-boot-dtb.bin >>${tmp}/out
+dd if=${tmp}/out of=${device} seek=64
+sync


### PR DESCRIPTION
This is a Rockchip RK3288-based board that uses SDwire for uSD access,
YKUSH for power and a serial console.

Signed-off-by: Simon Glass <sjg@chromium.org>